### PR TITLE
Adjust mobile header spacing and typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,17 +726,22 @@
             .profile-header {
                 flex-direction: row;
                 align-items: center;
-                gap: 12px;
+                gap: 16px;
                 text-align: left;
             }
 
             .profile-avatar {
-                width: 70px;
-                height: 70px;
+                width: 80px;
+                height: 80px;
+                border-radius: 50%;
             }
 
             .profile-info h1 {
-                font-size: 1.6rem;
+                font-size: 1.4rem;
+            }
+
+            .profile-username {
+                font-size: 0.9rem;
             }
 
             .social-links {
@@ -745,7 +750,7 @@
             }
 
             .subtitle {
-                font-size: 0.95rem;
+                font-size: 0.85rem;
             }
 
             .project-cards {


### PR DESCRIPTION
## Summary
- make profile picture larger and circular on mobile
- increase gap around profile picture
- reduce header content font sizes on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68894ef49ec8832388fd5d68d104d645