### PR TITLE
Add vibecode+ tags to personal projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,6 +603,16 @@
             font-weight: 400;
         }
 
+        .vibecode-tag {
+            background: rgba(0,0,0,0.02);
+            color: #999;
+            padding: 2px 6px;
+            border-radius: 10px;
+            font-size: 0.65rem;
+            font-weight: 400;
+            margin-left: 4px;
+        }
+
         .card-footer {
             margin-top: auto;
         }
@@ -907,13 +917,13 @@
                         <div class="featured-project">
                             <div class="featured-project-name"><a href="https://www.getmeetly.ai/" target="_blank" style="color: inherit; text-decoration: none;">Meetly</a></div>
                             <div class="featured-project-desc">AI-powered voice recording and transcript sharing tool</div>
-                            <div class="featured-project-status">Personal • Active</div>
+                            <div class="featured-project-status">Personal • Active <span class="vibecode-tag">vibecode+</span></div>
                         </div>
                         
                         <div class="featured-project">
                             <div class="featured-project-name">ProfilesAI.tech</div>
                             <div class="featured-project-desc">Privacy-first edge AI for better personalization</div>
-                            <div class="featured-project-status">Personal • Building</div>
+                            <div class="featured-project-status">Personal • Building <span class="vibecode-tag">vibecode+</span></div>
                         </div>
                     </div>
                 </div>
@@ -985,10 +995,11 @@
                                 <p class="card-description">
                                     AI-powered voice recording and transcript sharing tool. Record conversations, get instant transcriptions, and share insights with smart summaries.
                                 </p>
-                                                                 <div class="card-features">
+                                <div class="card-features">
                                      <span class="feature-tag">Voice Recording</span>
                                      <span class="feature-tag">AI Transcription</span>
                                      <span class="feature-tag">Smart Sharing</span>
+                                     <span class="feature-tag vibecode-tag">vibecode+</span>
                                  </div>
                              </div>
                              <div class="card-footer">
@@ -1017,6 +1028,7 @@
                                     <span class="feature-tag">Edge AI</span>
                                     <span class="feature-tag">Privacy-First</span>
                                     <span class="feature-tag">Personalization</span>
+                                    <span class="feature-tag vibecode-tag">vibecode+</span>
                                 </div>
                             </div>
                                                          <div class="card-footer">


### PR DESCRIPTION
## Summary
- Add subtle `.vibecode-tag` styling for vibecode+ labels
- Display vibecode+ tag on Meetly and ProfilesAI.tech personal projects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910a2917e083238620a6441d88623b